### PR TITLE
Migrate to python3 super() call style.

### DIFF
--- a/sources/models/component.py
+++ b/sources/models/component.py
@@ -553,7 +553,7 @@ class VariationGlyphs(list):
             variation.deepComponents._convertOffsetFromRCenterToTCenter()
 
     # def __iter__(self):
-    #     for x in super(VariationGlyphs, self).__iter__():
+    #     for x in super().__iter__():
     #         # print(dir(x))
     #         yield x._toDict()
 

--- a/sources/utils/vanillaPlus.py
+++ b/sources/utils/vanillaPlus.py
@@ -24,7 +24,7 @@ class SmartTextBox(TextBox):
         selectable=False, callback=None, sizeStyle=40.0,
         red=0,green=0,blue=0, alpha=1.0):
         self.color = NSColor.colorWithCalibratedRed_green_blue_alpha_(red, green, blue, alpha)
-        super(SmartTextBox, self).__init__(posSize, text=text, alignment=alignment, 
+        super().__init__(posSize, text=text, alignment=alignment, 
             selectable=selectable, sizeStyle=sizeStyle)
         
     def _setSizeStyle(self, sizeStyle):

--- a/sources/views/popover.py
+++ b/sources/views/popover.py
@@ -107,7 +107,7 @@ def resetDict(func):
 class EditPopoverAlignTool(EditPopover):
 
     def __init__(self, RCJKI, point, glyph):
-        super(EditPopoverAlignTool, self).__init__((170,210), point)
+        super().__init__((170,210), point)
         self.RCJKI = RCJKI
         self.glyph = glyph
         lib = self.getLib()

--- a/sources/views/roboCJKView.py
+++ b/sources/views/roboCJKView.py
@@ -72,7 +72,7 @@ class SmartTextBox(TextBox):
     def __init__(self, posSize, text="", alignment="natural", 
         selectable=False, callback=None, sizeStyle=40.0,
         red=0,green=0,blue=0, alpha=1.0):
-        super(SmartTextBox, self).__init__(posSize, text=text, alignment=alignment, 
+        super().__init__(posSize, text=text, alignment=alignment, 
             selectable=selectable, sizeStyle=sizeStyle)
         
     def _setSizeStyle(self, sizeStyle):

--- a/sources/views/tableDelegate.py
+++ b/sources/views/tableDelegate.py
@@ -45,7 +45,7 @@ class TableDelegate(NSObject):
         # ALWAYS call the super's designated initializer.  Also, make sure to
         # re-bind "self" just in case it returns something else, or even
         # None!
-        self = super(TableDelegate, self).init()
+        self = super().init()
         if self is None: return None
         self.glist = glist
         return self


### PR DESCRIPTION
This enables a future change which performs recursive module reloading, but it isn't possible to perform arbitrary-order reloading with the python2-style super(Foo, self) call style.

This change makes possible https://github.com/BlackFoundryCom/robo-cjk/pull/20.