### PR TITLE
added unsave modification feature in contextual menu

### DIFF
--- a/sources/controllers/roboCJK.py
+++ b/sources/controllers/roboCJK.py
@@ -148,6 +148,7 @@ class RoboCJKController(object):
 
         self.roundToGrid = False
         self.transformationToolIsActiv = False
+        self._unsave_modification = False
         self.importDCFromCG = None
         self.sliderValue = None
         self.sliderName = None
@@ -379,11 +380,17 @@ class RoboCJKController(object):
 
     def glyphWindowWillClose(self, notification):
         start = time.time()
-        self.roboCJKView.setglyphState(self.currentGlyph)
-        self.openedGlyphName = ""
         if self.glyphInspectorWindow is not None:
             self.glyphInspectorWindow.closeWindow()
             self.glyphInspectorWindow = None
+        if self._unsave_modification:
+            self._unsave_modification = False
+            self.currentFont.batchUnlockGlyphs([self.currentGlyph.name])
+            stop = time.time()
+            print(stop-start, "to close %s"%self.currentGlyph.name)
+            return
+        self.roboCJKView.setglyphState(self.currentGlyph)
+        self.openedGlyphName = ""
         try:
             posSize = CurrentGlyphWindow().window().getPosSize()
             setExtensionDefault(blackrobocjk_glyphwindowPosition, posSize)
@@ -888,7 +895,15 @@ class RoboCJKController(object):
             item = ('Import Axes and Sources from baseglyph', self.importAxesAndSourcesFromBaseglyph)
             self.menuItems.append(item)
 
+        item = ('Close glyph window without saving', self.closeWithoutSavingCallback)
+        self.menuItems.append(item)
+
         notification["additionContextualMenuItems"].extend(self.menuItems)
+
+
+    def closeWithoutSavingCallback(self, sender):
+        self._unsave_modification = True
+        CurrentGlyphWindow().close()
 
 
     def copyDCSettingsFromAnotherGlyphWindowSetUI(self, empty = False):


### PR DESCRIPTION
Added an item in the glyphwindow contextual menu to allow to close the glyph window without saving the modifications