### PR TITLE
Remove redundant lock check

### DIFF
--- a/sources/models/font.py
+++ b/sources/models/font.py
@@ -1061,8 +1061,6 @@ class Font():
     def saveGlyph(self, glyph):
         if glyph is None:
             return
-        if self.glyphLockedBy(glyph) != self.lockerUserName:
-            return
         name = glyph.name
         glyph.save()
         glyph._RGlyph.clearGuides()


### PR DESCRIPTION
This check is not needed as the DB checks the lock already and will respond 403 if we don't hold the lock.

Also, since #32, `saveGlyph()` isn't called when we don't hold the lock.